### PR TITLE
Collect and print subkeys

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -120,10 +120,13 @@ func (a *Analytics) Print() {
     fmt.Println("Key: " + a.key);
     fmt.Printf("Total Rows: %d\n", a.rows);
     fmt.Printf("Total Encounters: %d\n", a.encounters);
-    if a.encounters > 0 {
-        fmt.Printf("Average: %d\n", (a.sum / a.encounters));
+    if len(a.subkeys) > 0 {
+        fmt.Printf("Subkeys: %v\n", getSortedKeys(a.subkeys))
+    } else {
+        if a.encounters > 0 {
+            fmt.Printf("Average: %d\n", (a.sum / a.encounters));
+        }
+        fmt.Printf("Max: %d\n", a.max);
+        fmt.Printf("Min: %d\n", a.min);
     }
-    fmt.Printf("Max: %d\n", a.max);
-    fmt.Printf("Min: %d\n", a.min);
-    fmt.Printf("Subkeys: %v\n", getSortedKeys(a.subkeys))
 }

--- a/analytics.go
+++ b/analytics.go
@@ -88,7 +88,9 @@ func (a *Analytics) Print() {
     fmt.Println("Key: " + a.key);
     fmt.Printf("Total Rows: %d\n", a.rows);
     fmt.Printf("Total Encounters: %d\n", a.encounters);
-    fmt.Printf("Average: %d\n", (a.sum / a.encounters));
+    if a.encounters > 0 {
+        fmt.Printf("Average: %d\n", (a.sum / a.encounters));
+    }
     fmt.Printf("Max: %d\n", a.max);
     fmt.Printf("Min: %d\n", a.min);
 }

--- a/main.go
+++ b/main.go
@@ -1,8 +1,69 @@
 package main
 
+import (
+	"fmt"
+	"os"
+	"github.com/mgutz/minimist"
+)
+
+var name = "hewer"
+var version = "0.1.0"
+
+var usage = `
+hewer - Mine the crap out of some JSON-only log files
+
+Usage: hewer [options] file [files...]
+Options:
+   -k <key>, --key <key>  Collect stats for this JSON key
+   -h,       --help       Print this content and exit
+   -v,       --version    Print version and exit
+`
 
 func main() {
-	a := NewAnalytics("system.activeThreads");
-	ParseFile("/Users/bradbowie/Desktop/metrics-calamp-blue-20501.log", a);
-	a.Print();
+	// ParseFile("/Users/bradbowie/Desktop/metrics-calamp-blue-20501.log");
+
+	// parse command line args
+	argm := minimist.Parse()
+
+	// check for help flag
+	if argm.AsBool("help", "h", "?") {
+		helpAndExit()
+	}
+
+	// check for version flag
+	if argm.AsBool("v", "version") {
+		fmt.Println(version)
+		os.Exit(0)
+	}
+
+	// check for file args
+	args := argm["_"].([]string)
+	if len(args) < 1 {
+		helpAndExit()
+	}
+
+	//TODO verify existence of files
+
+	// fmt.Println("Mining files:", args)
+
+	// grab optional "key" flag and init analytics
+	key := argm.MayString("", "key", "k")
+	// fmt.Println("Using key:", key)
+
+	//analytics := NewAnalytics("system.activeThreads")
+	analytics := NewAnalytics(key)
+
+	//TODO parse mulitple files concurrently
+	for _, value := range args {
+		//fmt.Println(value)
+		ParseFile(value, analytics)
+	}
+
+	// print all results
+	analytics.Print();
+}
+
+func helpAndExit() {
+	fmt.Println(usage)
+	os.Exit(0)
 }


### PR DESCRIPTION
Adds a map-as-a-set to the `Analytics` struct, used to collect all subkeys of encountered maps. Then prints either subkeys as a sorted set (if any found) or stats (avg, min, max), but not both, since they should be mutually exclusive.

Sample output:

``` bash
# run without key
$ hewer metrics.log
Mining JSON file: metrics.log
Key: 
Total Rows: 7670
Total Encounters: 7670
Subkeys: [app errors ibMsg ibOps ibPool packets processingMs system time]

# run with key for json object
$ hewer metrics.log -k ibOps
Mining JSON file: metrics.log
Key: ibOps
Total Rows: 7670
Total Encounters: 7670
Subkeys: [decodeMs ibWorkerMs sendAcksMs sendObNotifMs updateStateMs]

# run with key for numeric value
$ hewer metrics.log -k ibOps.ibWorkerMs
Mining JSON file: metrics.log
Key: ibOps.ibWorkerMs
Total Rows: 7670
Total Encounters: 7670
Average: 8
Max: 527
Min: 4
```

**Note**: branched from _[cli](https://github.com/nexdrew/hewer/tree/cli)_, assumes [PR 1](https://github.com/brad-bowie/hewer/pull/1) will be merged first.
