### PR TITLE
Stats for JSON arrays

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -41,6 +41,8 @@ func (a *Analytics) NewRow(data map[string]interface{}) {
             a.numberEncountered(int(casted));
         case map[string]interface{}:
             a.mapEncountered(casted);
+        case []interface{}:
+            a.sliceEncountered(casted)
     }
 }
 
@@ -78,6 +80,15 @@ func (a *Analytics) mapEncountered(encountered map[string]interface{}) {
             }
         }
     }
+}
+
+func (a *Analytics) sliceEncountered(encountered []interface{}) {
+    //TODO if slice contains strings, then optionally group by value
+    //     e.g separate enc/sum/min/max per value
+    //     would require a struct as subset of Analytics
+    //     could either group string values by default or require a new cli flag
+    //     also, what about json objects with properties in slice?
+    a.numberEncountered(len(encountered))
 }
 
 func nestedGet(key string, data interface{}) (value interface{}) {


### PR DESCRIPTION
When the given key represents an array, it seems we should at least keep stats on the size of the array (i.e. count of items in the array) per line/JSON blob.

Example:

``` bash
$ hewer metrics.log -k packets
Mining JSON file: metrics.log
Key: packets
Total Rows: 7670
Total Encounters: 7670
Average: 2
Max: 2
Min: 2
```

This PR accounts for the absolute minimum we could do for arrays. It _does not_ account for any advanced handling of arrays, like:
- grouping by value for arrays of strings
- traversing and handling nested properties for arrays of objects

We may want to consider advanced handling for future enhancements.

**Note**: this branches from _[subkeys](https://github.com/nexdrew/hewer/tree/subkeys)_ and assumes [PR 2](https://github.com/brad-bowie/hewer/pull/2) will be merged first.
