### PR TITLE
Convert stubborn JSON values to usable types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ v0.2.0
 
 hewer is a log file miner, a CLI app that can quickly parse and summarize large amounts of data from one or more log files.
 
-The current implementation assumes a log file consists only of JSON content (one JSON blob per line).
+The current implementation assumes a log file consists of JSON content (one JSON blob per line).
 From this, hewer will auto-discover JSON property keys that can be targeted for statistical analysis.
 For details on the CLI, see [Usage](#usage) below.
 
@@ -38,8 +38,28 @@ $ hewer -v
 
 ### Usage
 
+#### Summarize JSON data
+
 ```
 $ hewer [-k <keyName>] <fileName> [<anotherFileName>...]
+$ hewer <fileName> [<anotherFileName>...] [-k <keyName>]
 ```
+
+Collect stats for a given JSON key (possibly nested) and print the collected info to stdout. If no key is given, hewer will default to the root object of each JSON blob. Can be used to "discover" the JSON structure(s) within the file(s).
+
+#### Convert JSON values
+
+```
+$ hewer -k <keyName> -c <type> <fileName> [<anotherFileName>...]
+$ hewer <fileName> [<anotherFileName>...] -k <keyName> -c <type>
+```
+
+Convert the values for a given JSON key to a more useful type and print the modified JSON to stdout, which you can redirect to write to another file. Valid values for `<type>` are:
+
+- `number` (convert string to floating point or integer number)
+- `json` (convert a JSON-encoded string to raw JSON)
+- `string` (convert something to a string).
+
+Lines from the input file(s) that are not JSON will be preserved as is. If no key is given, no conversion will be done and the original contents of the file(s) will be echoed.
 
 Run `hewer --help` for more information

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hewer
-v0.1.0
+v0.2.0
 
 ### What is hewer?
 

--- a/converter.go
+++ b/converter.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type Converter struct {
+	key    string
+	toType string
+}
+
+func NewConverter(key string, toType string) *Converter {
+	c := new(Converter)
+
+	c.key = key
+	c.toType = toType
+
+	return c
+}
+
+func (c *Converter) OnOtherData(bytes []byte) {
+	os.Stdout.Write(bytes)
+	fmt.Println()
+}
+
+func (c *Converter) OnJsonData(data map[string]interface{}) {
+	var owner map[string]interface{}
+	owner = nil
+	prop := c.key
+	var value interface{}
+	value = data
+
+	if c.key != "" {
+		keys := strings.Split(c.key, ".")
+		for _, k := range keys {
+			switch t := value.(type) {
+			case map[string]interface{}:
+				owner = t
+				prop = k
+				value = t[k]
+			}
+		}
+	}
+
+	if value != nil {
+		switch casted := value.(type) {
+		case string:
+			value = convertString(casted, c.toType)
+		case int: // don't think this will ever happen
+			value = convertInt(casted, c.toType)
+		case float64:
+			value = convertFloat(casted, c.toType)
+			// case map[string]interface{}:
+			// 	value = convertMap(casted, c.toType)
+			// case []interface{}:
+			// 	value = convertSlice(casted, c.toType)
+		}
+		if owner != nil {
+			owner[prop] = value
+		} else {
+			data = value.(map[string]interface{})
+		}
+	}
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		panic(err) //TODO: this is not the Go way
+	}
+	os.Stdout.Write(b)
+	fmt.Println()
+}
+
+func convertString(s string, toType string) (converted interface{}) {
+	converted = s
+	switch toType {
+	case "number":
+		if strings.Contains(s, ".") {
+			converted, _ = strconv.ParseFloat(s, 64)
+		} else {
+			converted, _ = strconv.Atoi(s)
+		}
+	case "json":
+		json.Unmarshal([]byte(s), &converted)
+	}
+	return converted
+}
+
+func convertInt(i int, toType string) (converted interface{}) {
+	converted = i
+	switch toType {
+	case "string":
+		converted = strconv.Itoa(i)
+	}
+	return converted
+}
+
+func convertFloat(f float64, toType string) (converted interface{}) {
+	converted = f
+	switch toType {
+	case "string":
+		converted = strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return converted
+}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ var name = "hewer"
 var version = "0.2.0"
 
 var usage = `
-Mine the crap out of some JSON-only log files
+Mine the crap out of some JSON-based log files
 
 Usage: hewer [options] file [files...]
 Options:

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ Options:
 
    -c <type>, --convert <type>  Convert the value at <key> to this type
                                 and print modified JSON to stdout. Valid
-								values are number, json, string
+                                values are number, json, string
 
    -h, --help                   Print this content and exit
 

--- a/main.go
+++ b/main.go
@@ -7,21 +7,26 @@ import (
 )
 
 var name = "hewer"
-var version = "0.1.0"
+var version = "0.2.0"
 
 var usage = `
-hewer - Mine the crap out of some JSON-only log files
+Mine the crap out of some JSON-only log files
 
 Usage: hewer [options] file [files...]
 Options:
-   -k <key>, --key <key>  Collect stats for this JSON key
-   -h,       --help       Print this content and exit
-   -v,       --version    Print version and exit
+   -k <key>, --key <key>        Operate on this JSON key, either collecting
+                                stats or converting its values
+
+   -c <type>, --convert <type>  Convert the value at <key> to this type
+                                and print modified JSON to stdout. Valid
+								values are number, json, string
+
+   -h, --help                   Print this content and exit
+
+   -v, --version                Print version and exit
 `
 
 func main() {
-	// ParseFile("/Users/bradbowie/Desktop/metrics-calamp-blue-20501.log");
-
 	// parse command line args
 	argm := minimist.Parse()
 
@@ -44,23 +49,25 @@ func main() {
 
 	//TODO verify existence of files
 
-	// fmt.Println("Mining files:", args)
-
 	// grab optional "key" flag and init analytics
 	key := argm.MayString("", "key", "k")
-	// fmt.Println("Using key:", key)
 
-	//analytics := NewAnalytics("system.activeThreads")
-	analytics := NewAnalytics(key)
+	convert := argm.MayString("", "convert", "c")
 
 	//TODO parse mulitple files concurrently
-	for _, value := range args {
-		//fmt.Println(value)
-		ParseFile(value, analytics)
+	if convert == "" {
+		analytics := NewAnalytics(key)
+		for _, value := range args {
+			ParseFile(value, analytics)
+		}
+		// print all results
+		analytics.Print()
+	} else {
+		converter := NewConverter(key, convert)
+		for _, value := range args {
+			ParseAndConvertFile(value, converter)
+		}
 	}
-
-	// print all results
-	analytics.Print()
 }
 
 func helpAndExit() {

--- a/miner.go
+++ b/miner.go
@@ -38,3 +38,29 @@ func ParseFile(fileName string, analytics *Analytics) {
 		fmt.Printf("Skipped %d non-JSON lines in '%s'.\n", skippedLines, fileName)
 	}
 }
+
+func ParseAndConvertFile(fileName string, converter *Converter) {
+	file, err := os.Open(fileName)
+
+	if err != nil {
+		panic(err.Error())
+	}
+
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	scanner := bufio.NewScanner(reader)
+	var data map[string]interface{} //TODO: support other types via interface{}
+
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		bytes := scanner.Bytes()
+		err := json.Unmarshal(bytes, &data)
+
+		if err == nil {
+			converter.OnJsonData(data)
+		} else {
+			converter.OnOtherData(bytes)
+		}
+	}
+}


### PR DESCRIPTION
Initial changes to support JSON modification via converting one key at a time to a more usable data type and printing the modified content to stdout, which can be redirected to write to file.

Here's an example (old output from trackpipe):

``` sh
$ hewer cgw-12k.log -k analytics
Mining JSON file: cgw-12k.log
Total Rows: 3
JSON Rows: 3
Key: analytics
Total Encounters: 3
```

What? Where are subkeys? (Look at file.) Oh, `analytics` is a JSON-encoded string. Ok, let's do this:

``` sh
$ hewer cgw-12k.log -k analytics -c json > cgw-12k-converted.log
$ hewer cgw-12k-converted.log -k analytics
Mining JSON file: cgw-12k-converted.log
Total Rows: 3
JSON Rows: 3
Key: analytics
Total Encounters: 3
Subkeys: [activeTrackers activitySeconds packetLoss responses runtimeSeconds tracks]
```

That's better. Now let's try `analytics.packetLoss.percentage`:

``` sh
$ hewer cgw-12k-converted.log -k analytics.packetLoss.percentage
Mining JSON file: cgw-12k-converted.log
Total Rows: 3
JSON Rows: 3
Key: analytics.packetLoss.percentage
Total Encounters: 3
```

Well, crap. (Look in file again.) Oh, those values are strings. Take this:

``` sh
$ hewer cgw-12k-converted.log -k analytics.packetLoss.percentage -c number > cgw-12k-usable.log
$ hewer cgw-12k-usable.log -k analytics.packetLoss.percentage
Mining JSON file: cgw-12k-usable.log
Total Rows: 3
JSON Rows: 3
Key: analytics.packetLoss.percentage
Total Encounters: 3
Average: 73
Max: 80
Min: 62
```

Ah, there we go.

Also bumped the minor version since stuff was added to the CLI.

``` sh
$ hewer -v
0.2.0
```
