### PR TITLE
Use floats (instead of ints) for analytics

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"math"
+	"sort"
+	"strconv"
+)
+
+func AddStringToSet(str string, mapAsSet map[string]struct{}) {
+	if _, inSet := mapAsSet[str]; !inSet {
+		mapAsSet[str] = struct{}{}
+	}
+}
+
+func GetSortedKeys(m map[string]struct{}) []string {
+	sortedKeys := make([]string, len(m))
+	i := 0
+	for k, _ := range m {
+		sortedKeys[i] = k
+		i++
+	}
+	sort.Strings(sortedKeys)
+	return sortedKeys
+}
+
+// totally stole this from https://gist.github.com/DavidVaini/10308388#comment-1391788
+func RoundToPrecision(f float64, precision int) float64 {
+	shift := math.Pow(10, float64(precision))
+	return math.Floor((f*shift)+.5) / shift
+}
+
+func PrettyFormatFloat(f float64) string {
+	rounded := RoundToPrecision(f, 3)
+	return strconv.FormatFloat(rounded, 'f', -1, 64)
+}


### PR DESCRIPTION
Rounds displayed floats to 3 decimal places by default, but it will print fewer if 3 are not needed to represent the full value.

Took the opportunity to move some utility functions to a new `utils.go` file as well.

Ran code changes thru `go fmt` - that's why some spacing was removed.

Some examples:

``` sh
$ hewer cgw-12k-fix2.log -k analytics.activitySeconds
Mining JSON file: cgw-12k-fix2.log
Total Rows: 3
JSON Rows: 3
Key: analytics.activitySeconds
Total Encounters: 3
Average: 63.398
Max: 64.251
Min: 62.869
```

``` sh
$ hewer cgw-12k-fix2.log -k analytics.packetLoss.percentage
Mining JSON file: cgw-12k-fix2.log
Total Rows: 3
JSON Rows: 3
Key: analytics.packetLoss.percentage
Total Encounters: 3
Average: 74.52
Max: 80.95
Min: 62.78
```

``` sh
$ hewer cgw-12k-fix2.log -k analytics.packetLoss.total
Mining JSON file: cgw-12k-fix2.log
Total Rows: 3
JSON Rows: 3
Key: analytics.packetLoss.total
Total Encounters: 3
Average: 8942.667
Max: 9714
Min: 7534
```

``` sh
$ hewer cgw-12k-fix2.log -k analytics.activeTrackers
Mining JSON file: cgw-12k-fix2.log
Total Rows: 3
JSON Rows: 3
Key: analytics.activeTrackers
Total Encounters: 3
Average: 0
Max: 0
Min: 0
```

``` sh
$ hewer metrics-calamp-blue-20500.log.2015-06-18 -k packets
Mining JSON file: metrics-calamp-blue-20500.log.2015-06-18
Total Rows: 1815
JSON Rows: 1815
Key: packets
Total Encounters: 1815
Average: 1.986
Max: 2
Min: 1
```
